### PR TITLE
Support arbitrary query params for getAll* functions, getAllCustomResources signature change

### DIFF
--- a/README.md
+++ b/README.md
@@ -126,7 +126,7 @@ with valid values for tenantId, apiKey and accessToken
     * [.updateOrgUnit(orgUnitPKey, orgUnitObject)](#CampaignStandardCoreAPI+updateOrgUnit)
     * [.postDataToUrl(url, body)](#CampaignStandardCoreAPI+postDataToUrl)
     * [.getDataFromRelativeUrl(relativeUrl)](#CampaignStandardCoreAPI+getDataFromRelativeUrl)
-    * [.getAllCustomResources([parameters])](#CampaignStandardCoreAPI+getAllCustomResources)
+    * [.getAllCustomResources(customResource, [parameters])](#CampaignStandardCoreAPI+getAllCustomResources)
     * [.updateCustomResource(customResource, customResourcePKey, customResourceObject)](#CampaignStandardCoreAPI+updateCustomResource)
     * [.createCustomResource(customResource, customResourceObject)](#CampaignStandardCoreAPI+createCustomResource)
     * [.deleteCustomResource(customResource, customResourcePKey, customResourceObject)](#CampaignStandardCoreAPI+deleteCustomResource)
@@ -449,7 +449,7 @@ Gets data from a relative url. Helper function.
 
 <a name="CampaignStandardCoreAPI+getAllCustomResources"></a>
 
-### campaignStandardCoreAPI.getAllCustomResources([parameters])
+### campaignStandardCoreAPI.getAllCustomResources(customResource, [parameters])
 Get all Custom Resource records
 
 **Kind**: instance method of [<code>CampaignStandardCoreAPI</code>](#CampaignStandardCoreAPI)  
@@ -457,8 +457,8 @@ Get all Custom Resource records
 
 | Param | Type | Default | Description |
 | --- | --- | --- | --- |
+| customResource | <code>string</code> |  | the custom resource to get records from |
 | [parameters] | <code>Object</code> | <code>{}</code> | parameters to pass |
-| [parameters.customResource] | <code>string</code> |  | the custom resource to get records from |
 | [parameters.filters] | <code>Array</code> | <code>[]</code> | apply the filters to the results. List of filters for a resource can be retrieved via a getMetadataForResource call |
 | [parameters.hasCustomFilter] | <code>Boolean</code> | <code>false</code> | set to true if you have a custom filter. Defaults to false. |
 | [parameters.lineCount] | <code>integer</code> | <code>25</code> | limit the number of records to return (default is 25) |

--- a/bin/validate_spec.js
+++ b/bin/validate_spec.js
@@ -2,7 +2,7 @@
 
 const path = require('path')
 
-let arg = '../spec/campaign_standard_api.json'
+let arg = '../spec/api.json'
 if (process.argv.length > 2) {
   arg = path.resolve(process.argv[2])
 }

--- a/package.json
+++ b/package.json
@@ -6,7 +6,7 @@
   "license": "Apache-2.0",
   "main": "src/index.js",
   "scripts": {
-    "validate": "node bin/validate_spec.js spec/campaign_standard_api.json",
+    "validate": "node bin/validate_spec.js spec/api.json",
     "test": "npm run validate && npm run lint && npm run unit-tests",
     "lint": "eslint src test",
     "unit-tests": "jest --config test/jest.config.js --maxWorkers=2",

--- a/spec/api.json
+++ b/spec/api.json
@@ -180,7 +180,18 @@
           "type": "string",
           "default": "application/json;charset=utf-8"
         }
-      }
+      },
+      "FreeFormQueryParameters": {
+        "in": "query",
+        "name": "freeForm",
+        "schema": {
+          "type": "object",
+          "additionalProperties": {
+            "type": "string"
+          }
+        },
+        "style": "form"
+      }      
     }
   },
   "security": [
@@ -194,6 +205,9 @@
   "paths": {
     "/profileAndServices{EXT}/profile/{FILTERS}": {
       "parameters": [
+        {
+          "$ref": "#/components/parameters/FreeFormQueryParameters"
+        },
         {
           "$ref": "#/components/parameters/Ext"
         },
@@ -275,6 +289,9 @@
     },
     "/profileAndServices{EXT}/service/{FILTERS}": {
       "parameters": [
+        {
+          "$ref": "#/components/parameters/FreeFormQueryParameters"
+        },
         {
           "$ref": "#/components/parameters/Ext"
         },
@@ -697,6 +714,9 @@
     "/profileAndServicesExt/orgUnitBase/{FILTERS}": {
       "parameters": [
         {
+          "$ref": "#/components/parameters/FreeFormQueryParameters"
+        },
+        {
           "$ref": "#/components/parameters/Filters"
         },
         {
@@ -732,6 +752,9 @@
           "schema": {
             "type": "string"
           }
+        },
+        {
+          "$ref": "#/components/parameters/FreeFormQueryParameters"
         },
         {
           "$ref": "#/components/parameters/Filters"

--- a/src/index.js
+++ b/src/index.js
@@ -104,32 +104,47 @@ class CampaignStandardCoreAPI {
     })
   }
 
-  __createFilterParams ({ filters, hasCustomFilter, lineCount, order, descendingSort } = {}) {
-    const params = {
+  __createFilterParams (params) {
+    const { filters, hasCustomFilter, lineCount, order, descendingSort } = params
+    const fixedParams = ['filters', 'hasCustomFilter', 'lineCount', 'order', 'descendingSort']
+
+    const retParams = {
       EXT: '',
       FILTERS: []
     }
 
+    // filter for extra keys, set these to the 'freeForm' property (for free-form query parameters)
+    retParams.freeForm = Object.keys(params)
+      .filter(key => !fixedParams.includes(key))
+      .reduce((o, key) => {
+        o[key] = params[key]
+        return o
+      }, {})
+
     if (filters) {
-      params.FILTERS = filters.join('/')
+      // this is a fixed path param
+      retParams.FILTERS = filters.join('/')
     }
 
     if (hasCustomFilter) {
-      params.EXT = 'Ext'
+      // this is modifies the url (append to resource)
+      retParams.EXT = 'Ext'
     }
 
+    // this is a fixed query param
     if (lineCount) { // lineCount default is 25
-      params._lineCount = lineCount
+      retParams._lineCount = lineCount
     }
 
     if (order) {
-      params._order = order
+      // this is a fixed query param
+      retParams._order = order
       if (descendingSort) { // ascending is the default
-        params._order += '%20desc'
+        retParams._order += '%20desc'
       }
     }
 
-    return params
+    return retParams
   }
 
   /**

--- a/src/index.js
+++ b/src/index.js
@@ -61,7 +61,7 @@ class CampaignStandardCoreAPI {
    */
   async init (tenantId, apiKey, accessToken) {
     // init swagger client
-    const spec = require('../spec/campaign_standard_api.json')
+    const spec = require('../spec/api.json')
     const swagger = new Swagger({
       spec: spec,
       requestInterceptor,

--- a/src/index.js
+++ b/src/index.js
@@ -104,7 +104,7 @@ class CampaignStandardCoreAPI {
     })
   }
 
-  __createFilterParams (params) {
+  __createFilterParams (params = {}) {
     const { filters, hasCustomFilter, lineCount, order, descendingSort } = params
     const fixedParams = ['filters', 'hasCustomFilter', 'lineCount', 'order', 'descendingSort']
 
@@ -676,7 +676,9 @@ class CampaignStandardCoreAPI {
     const sdkDetails = { parameters }
 
     return new Promise((resolve, reject) => {
-      const filterParams = { ...this.__createFilterParams(parameters), CUSTOMRESOURCE: parameters.customResource }
+      const customResource = parameters.customResource ? String(parameters.customResource) : ''
+      delete parameters.customResource
+      const filterParams = { ...this.__createFilterParams(parameters), CUSTOMRESOURCE: customResource }
       this.sdk.apis.customresource.getAllCustomResources(filterParams, this.__createRequestOptions())
         .then(response => {
           resolve(response)

--- a/src/index.js
+++ b/src/index.js
@@ -662,8 +662,8 @@ class CampaignStandardCoreAPI {
   /**
    * Get all Custom Resource records
    *
+   * @param {string} customResource the custom resource to get records from
    * @param {Object} [parameters={}] parameters to pass
-   * @param {string} [parameters.customResource] the custom resource to get records from
    * @param {Array} [parameters.filters=[]] apply the filters to the results. List of filters for a resource can be retrieved via a getMetadataForResource call
    * @param {Boolean} [parameters.hasCustomFilter=false] set to true if you have a custom filter. Defaults to false.
    * @param {integer} [parameters.lineCount=25] limit the number of records to return (default is 25)
@@ -672,12 +672,10 @@ class CampaignStandardCoreAPI {
    *
    * @see getMetadataForResource
    */
-  getAllCustomResources (parameters) {
-    const sdkDetails = { parameters }
+  getAllCustomResources (customResource, parameters) {
+    const sdkDetails = { customResource, parameters }
 
     return new Promise((resolve, reject) => {
-      const customResource = parameters.customResource ? String(parameters.customResource) : ''
-      delete parameters.customResource
       const filterParams = { ...this.__createFilterParams(parameters), CUSTOMRESOURCE: customResource }
       this.sdk.apis.customresource.getAllCustomResources(filterParams, this.__createRequestOptions())
         .then(response => {

--- a/test/index.test.js
+++ b/test/index.test.js
@@ -105,7 +105,7 @@ async function standardTest ({
 
 test('getAllProfiles', async () => {
   const sdkArgs = []
-  const apiParameters = { EXT: '', FILTERS: [] } // equiv to default
+  const apiParameters = { EXT: '', FILTERS: [], freeForm: {} } // equiv to default
   const apiOptions = createSwaggerOptions()
 
   return standardTest({
@@ -135,7 +135,8 @@ test('getAllProfiles - with filters', async () => {
       FILTERS: 'byEmail/byText/myCustomFilter',
       EXT: 'Ext',
       _lineCount: 10,
-      _order: descendingSort ? 'email%20desc' : 'email'
+      _order: descendingSort ? 'email%20desc' : 'email',
+      freeForm: {}
     }
   }
 
@@ -211,7 +212,7 @@ test('getProfile', async () => {
 
 test('getAllServices', async () => {
   const sdkArgs = []
-  const apiParameters = { EXT: '', FILTERS: [] } // equiv to default
+  const apiParameters = { EXT: '', FILTERS: [], freeForm: {} } // equiv to default
   const apiOptions = createSwaggerOptions()
 
   return standardTest({
@@ -558,7 +559,7 @@ test('controlWorkflow - invalid resource', async () => {
 
 test('getAllOrgUnits', async () => {
   const sdkArgs = []
-  const apiParameters = { EXT: '', FILTERS: [] } // equiv to default
+  const apiParameters = { EXT: '', FILTERS: [], freeForm: {} } // equiv to default
   const apiOptions = createSwaggerOptions()
 
   return standardTest({
@@ -649,7 +650,7 @@ test('getAllCustomResources', async () => {
   const customResource = 'mycustomresource'
 
   const sdkArgs = [{ customResource }]
-  const apiParameters = { CUSTOMRESOURCE: customResource, EXT: '', FILTERS: [] } // equiv to default
+  const apiParameters = { CUSTOMRESOURCE: customResource, EXT: '', FILTERS: [], freeForm: {} } // equiv to default
   const apiOptions = createSwaggerOptions()
 
   return standardTest({

--- a/test/index.test.js
+++ b/test/index.test.js
@@ -104,8 +104,8 @@ async function standardTest ({
 }
 
 test('getAllProfiles', async () => {
-  const sdkArgs = []
-  const apiParameters = { EXT: '', FILTERS: [], freeForm: {} } // equiv to default
+  const sdkArgs = [{ email: 'name@example.com' }]
+  const apiParameters = { EXT: '', FILTERS: [], freeForm: { email: 'name@example.com' } } // equiv to default
   const apiOptions = createSwaggerOptions()
 
   return standardTest({
@@ -649,7 +649,7 @@ test('getDataFromRelativeUrl', async () => {
 test('getAllCustomResources', async () => {
   const customResource = 'mycustomresource'
 
-  const sdkArgs = [{ customResource }]
+  const sdkArgs = [customResource]
   const apiParameters = { CUSTOMRESOURCE: customResource, EXT: '', FILTERS: [], freeForm: {} } // equiv to default
   const apiOptions = createSwaggerOptions()
 


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description

for `getAll*` functions, it didn't support arbitrary query parameters.
This adds support via the `parameters` object, just add the property there. Any unknown (non-fixed)  parameters will be passed as query parameters now.

For example, you could have the filter `byEmail` which requires the query parameter `email` and you had no way to pass that on before. 

for `getAllCustomResources`, the api signature has changed. `customResource` is required as the first parameter now, like all the other custom resource functions.

Both types of changes requires a major version bump.

## Motivation and Context

Bug fix

## How Has This Been Tested?

npm test

## Types of changes

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->

- [X] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [X] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [X] I have signed the [Adobe Open Source CLA](http://opensource.adobe.com/cla.html).
- [X] My code follows the code style of this project.
- [X] My change requires a change to the documentation.
- [X] I have updated the documentation accordingly.
- [X] I have read the **CONTRIBUTING** document.
- [X] I have added tests to cover my changes.
- [X] All new and existing tests passed.
