### PR TITLE
fix auth object for pure fetch requests (no swagger)

### DIFF
--- a/src/index.js
+++ b/src/index.js
@@ -632,8 +632,8 @@ class CampaignStandardCoreAPI {
       headers: {
         'Content-Type': 'application/json;charset=utf-8',
         'Cache-Control': 'no-cache',
-        Authorization: `Bearer ${options.accessToken}`,
-        'X-Api-Key': options.apiKey
+        Authorization: `Bearer ${options.securities.authorized.BearerAuth.value}`,
+        'X-Api-Key': options.securities.authorized.ApiKeyAuth.value
       }
     })
 


### PR DESCRIPTION
As the URL for external activity triggering is returned as an absolute URL (including https://...), the correspondent `triggerSignalActivity` method has to use fetch to call the URL directly (instead of calling via swagger spec). That also requires auth objects to be read differently.

## Description

We need to change the request to event triggering API in a way that it reads correctly from the request object intended for swagger.

## Types of changes

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:

- [x] I have signed the [Adobe Open Source CLA](http://opensource.adobe.com/cla.html).
- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [x] I have read the **CONTRIBUTING** document.
- [ ] I have added tests to cover my changes.
- [ ] All new and existing tests passed.
