### PR TITLE
fix: GET calls fail with swagger client 3.10.2 or higher because of empty body in calls

### DIFF
--- a/package.json
+++ b/package.json
@@ -17,7 +17,7 @@
     "@adobe/aio-lib-core-errors": "^3.0.0",
     "@adobe/aio-lib-core-logging": "^1.1.2",
     "cross-fetch": "^3.0.4",
-    "swagger-client": "3.9.6"
+    "swagger-client": "3.10.2"
   },
   "files": [
     "src",

--- a/package.json
+++ b/package.json
@@ -17,7 +17,7 @@
     "@adobe/aio-lib-core-errors": "^3.0.0",
     "@adobe/aio-lib-core-logging": "^1.1.2",
     "cross-fetch": "^3.0.4",
-    "swagger-client": "3.10.2"
+    "swagger-client": "3.9.6"
   },
   "files": [
     "src",

--- a/src/index.js
+++ b/src/index.js
@@ -163,7 +163,7 @@ class CampaignStandardCoreAPI {
     const sdkDetails = { parameters }
 
     return new Promise((resolve, reject) => {
-      this.sdk.apis.profile.getAllProfiles(this.__createFilterParams(parameters), this.__createRequestOptions())
+      this.sdk.apis.profile.getAllProfiles(this.__createFilterParams(parameters), this.__createRequestOptions({ body: null }))
         .then(response => {
           resolve(response)
         })
@@ -221,7 +221,7 @@ class CampaignStandardCoreAPI {
     const sdkDetails = { profilePKey }
 
     return new Promise((resolve, reject) => {
-      this.sdk.apis.profile.getProfile({ PROFILE_PKEY: profilePKey }, this.__createRequestOptions())
+      this.sdk.apis.profile.getProfile({ PROFILE_PKEY: profilePKey }, this.__createRequestOptions({ body: null }))
         .then(response => {
           resolve(response)
         })
@@ -247,7 +247,7 @@ class CampaignStandardCoreAPI {
     const sdkDetails = { parameters }
 
     return new Promise((resolve, reject) => {
-      this.sdk.apis.service.getAllServices(this.__createFilterParams(parameters), this.__createRequestOptions())
+      this.sdk.apis.service.getAllServices(this.__createFilterParams(parameters), this.__createRequestOptions({ body: null }))
         .then(response => {
           resolve(response)
         })
@@ -285,7 +285,7 @@ class CampaignStandardCoreAPI {
     const sdkDetails = { servicePKey }
 
     return new Promise((resolve, reject) => {
-      this.sdk.apis.service.getService({ SERVICE_PKEY: servicePKey }, this.__createRequestOptions())
+      this.sdk.apis.service.getService({ SERVICE_PKEY: servicePKey }, this.__createRequestOptions({ body: null }))
         .then(response => {
           resolve(response)
         })
@@ -304,7 +304,7 @@ class CampaignStandardCoreAPI {
     const sdkDetails = { profilePKey }
 
     return new Promise((resolve, reject) => {
-      this.sdk.apis.history.getHistoryOfProfile({ PROFILE_PKEY: profilePKey }, this.__createRequestOptions())
+      this.sdk.apis.history.getHistoryOfProfile({ PROFILE_PKEY: profilePKey }, this.__createRequestOptions({ body: null }))
         .then(response => {
           resolve(response)
         })
@@ -328,7 +328,7 @@ class CampaignStandardCoreAPI {
         reject(new codes.ERROR_INVALID_RESOURCE_TYPE({ sdkDetails, messageValues: `${acceptedResources.join(', ')}` }))
       }
 
-      this.sdk.apis.metadata.getMetadataForResource({ RESOURCE: resource }, this.__createRequestOptions())
+      this.sdk.apis.metadata.getMetadataForResource({ RESOURCE: resource }, this.__createRequestOptions({ body: null }))
         .then(response => {
           resolve(response)
         })
@@ -347,7 +347,7 @@ class CampaignStandardCoreAPI {
     const sdkDetails = { resource }
 
     return new Promise((resolve, reject) => {
-      this.sdk.apis.metadataExt.getMetadataForResourceExt({ RESOURCE: resource }, this.__createRequestOptions())
+      this.sdk.apis.metadataExt.getMetadataForResourceExt({ RESOURCE: resource }, this.__createRequestOptions({ body: null }))
         .then(response => {
           resolve(response)
         })
@@ -362,7 +362,7 @@ class CampaignStandardCoreAPI {
    */
   getCustomResources () {
     return new Promise((resolve, reject) => {
-      this.sdk.apis.metadata.getCustomResources({}, this.__createRequestOptions())
+      this.sdk.apis.metadata.getCustomResources({}, this.__createRequestOptions({ body: null }))
         .then(response => {
           resolve(response)
         })
@@ -396,7 +396,7 @@ class CampaignStandardCoreAPI {
    */
   getGDPRRequest () {
     return new Promise((resolve, reject) => {
-      this.sdk.apis.gdpr.getGDPRRequest({}, this.__createRequestOptions())
+      this.sdk.apis.gdpr.getGDPRRequest({}, this.__createRequestOptions({ body: null }))
         .then(response => {
           resolve(response)
         })
@@ -492,7 +492,7 @@ class CampaignStandardCoreAPI {
           ORGANIZATION: macTenantId,
           EVENT_ID: eventId,
           EVENT_PKEY: eventPKey
-        }, this.__createRequestOptions())
+        }, this.__createRequestOptions({ body: null }))
         .then(response => {
           resolve(response)
         })
@@ -511,7 +511,7 @@ class CampaignStandardCoreAPI {
     const sdkDetails = { workflowId }
 
     return new Promise((resolve, reject) => {
-      this.sdk.apis.workflow.getWorkflow({ WORKFLOW_ID: workflowId }, this.__createRequestOptions())
+      this.sdk.apis.workflow.getWorkflow({ WORKFLOW_ID: workflowId }, this.__createRequestOptions({ body: null }))
         .then(response => {
           resolve(response)
         })
@@ -586,7 +586,7 @@ class CampaignStandardCoreAPI {
     const sdkDetails = { parameters }
 
     return new Promise((resolve, reject) => {
-      this.sdk.apis.organization.getAllOrgUnits(this.__createFilterParams(parameters), this.__createRequestOptions())
+      this.sdk.apis.organization.getAllOrgUnits(this.__createFilterParams(parameters), this.__createRequestOptions({ body: null }))
         .then(response => {
           resolve(response)
         })
@@ -605,7 +605,7 @@ class CampaignStandardCoreAPI {
     const sdkDetails = { profilePKey }
 
     return new Promise((resolve, reject) => {
-      this.sdk.apis.organization.getProfileWithOrgUnit({ PROFILE_PKEY: profilePKey }, this.__createRequestOptions())
+      this.sdk.apis.organization.getProfileWithOrgUnit({ PROFILE_PKEY: profilePKey }, this.__createRequestOptions({ body: null }))
         .then(response => {
           resolve(response)
         })
@@ -695,7 +695,7 @@ class CampaignStandardCoreAPI {
     const sdkDetails = { relativeUrl }
 
     return new Promise((resolve, reject) => {
-      this.sdk.apis.util.getDataFromRelativeUrl({ RELATIVE_URL: relativeUrl }, this.__createRequestOptions())
+      this.sdk.apis.util.getDataFromRelativeUrl({ RELATIVE_URL: relativeUrl }, this.__createRequestOptions({ body: null }))
         .then(response => {
           resolve(response)
         })
@@ -726,7 +726,7 @@ class CampaignStandardCoreAPI {
     logger.warn('getAllCustomResources has been deprecated, either use getAllBasicCustomResources() to get custom resources or getAllProfileAndServicesExt() to get extended resource data')
     return new Promise((resolve, reject) => {
       const filterParams = { ...this.__createFilterParams(parameters), CUSTOMRESOURCE: customResource }
-      this.sdk.apis.customresource.getAllCustomResources(filterParams, this.__createRequestOptions())
+      this.sdk.apis.customresource.getAllCustomResources(filterParams, this.__createRequestOptions({ body: null }))
         .then(response => {
           resolve(response)
         })
@@ -745,7 +745,7 @@ class CampaignStandardCoreAPI {
     const sdkDetails = { resource }
 
     return new Promise((resolve, reject) => {
-      this.sdk.apis.basiccustomresource.getAllBasicCustomResources({ RESOURCE: resource }, this.__createRequestOptions())
+      this.sdk.apis.basiccustomresource.getAllBasicCustomResources({ RESOURCE: resource }, this.__createRequestOptions({ body: null }))
         .then(response => {
           resolve(response)
         })
@@ -773,7 +773,7 @@ class CampaignStandardCoreAPI {
 
     return new Promise((resolve, reject) => {
       const filterParams = { ...this.__createFilterParams(parameters), CUSTOMRESOURCE: customResource }
-      this.sdk.apis.customresource.getAllCustomResources(filterParams, this.__createRequestOptions())
+      this.sdk.apis.customresource.getAllCustomResources(filterParams, this.__createRequestOptions({ body: null }))
         .then(response => {
           resolve(response)
         })

--- a/test/index.test.js
+++ b/test/index.test.js
@@ -105,7 +105,7 @@ async function standardTest ({
 test('getAllProfiles', async () => {
   const sdkArgs = [{ email: 'name@example.com' }]
   const apiParameters = { EXT: '', FILTERS: [], freeForm: { email: 'name@example.com' } } // equiv to default
-  const apiOptions = createSwaggerOptions()
+  const apiOptions = createSwaggerOptions({ body: null })
 
   return expect(() => standardTest({
     fullyQualifiedApiName: 'profile.getAllProfiles',
@@ -139,7 +139,7 @@ test('getAllProfiles - with filters', async () => {
     }
   }
 
-  const apiOptions = createSwaggerOptions()
+  const apiOptions = createSwaggerOptions({ body: null })
 
   // descending sort
   await standardTest({
@@ -199,7 +199,7 @@ test('getProfile', async () => {
 
   const sdkArgs = [pkey]
   const apiParameters = { PROFILE_PKEY: pkey }
-  const apiOptions = createSwaggerOptions()
+  const apiOptions = createSwaggerOptions({ body: null })
 
   return expect(() => standardTest({
     fullyQualifiedApiName: 'profile.getProfile',
@@ -213,7 +213,7 @@ test('getProfile', async () => {
 test('getAllServices', async () => {
   const sdkArgs = []
   const apiParameters = { EXT: '', FILTERS: [], freeForm: {} } // equiv to default
-  const apiOptions = createSwaggerOptions()
+  const apiOptions = createSwaggerOptions({ body: null })
 
   return expect(() => standardTest({
     fullyQualifiedApiName: 'service.getAllServices',
@@ -251,7 +251,7 @@ test('getService', async () => {
 
   const sdkArgs = [pkey]
   const apiParameters = { SERVICE_PKEY: pkey }
-  const apiOptions = createSwaggerOptions()
+  const apiOptions = createSwaggerOptions({ body: null })
 
   return expect(() => standardTest({
     fullyQualifiedApiName: 'service.getService',
@@ -267,7 +267,7 @@ test('getHistoryOfProfile', async () => {
 
   const sdkArgs = [pkey]
   const apiParameters = { PROFILE_PKEY: pkey }
-  const apiOptions = createSwaggerOptions()
+  const apiOptions = createSwaggerOptions({ body: null })
 
   return expect(() => standardTest({
     fullyQualifiedApiName: 'history.getHistoryOfProfile',
@@ -283,7 +283,7 @@ test('getMetadataForResource', async () => {
 
   const sdkArgs = [resource]
   const apiParameters = { RESOURCE: resource }
-  const apiOptions = createSwaggerOptions()
+  const apiOptions = createSwaggerOptions({ body: null })
 
   return expect(() => standardTest({
     fullyQualifiedApiName: 'metadata.getMetadataForResource',
@@ -306,7 +306,7 @@ test('getMetadataForResource - invalid resource', async () => {
 test('getCustomResources', async () => {
   const sdkArgs = []
   const apiParameters = {}
-  const apiOptions = createSwaggerOptions()
+  const apiOptions = createSwaggerOptions({ body: null })
 
   return expect(() => standardTest({
     fullyQualifiedApiName: 'metadata.getCustomResources',
@@ -342,7 +342,7 @@ test('createGDPRRequest', async () => {
 test('getGDPRRequest', async () => {
   const sdkArgs = []
   const apiParameters = {}
-  const apiOptions = createSwaggerOptions()
+  const apiOptions = createSwaggerOptions({ body: null })
 
   return expect(() => standardTest({
     fullyQualifiedApiName: 'gdpr.getGDPRRequest',
@@ -431,7 +431,7 @@ test('getTransactionalEvent', async () => {
 
   const sdkArgs = [eventId, eventPKey]
   const apiParameters = { EVENT_ID: eventId, ORGANIZATION: gTenantId, EVENT_PKEY: eventPKey }
-  const apiOptions = createSwaggerOptions()
+  const apiOptions = createSwaggerOptions({ body: null })
 
   return expect(() => standardTest({
     fullyQualifiedApiName: 'messaging.getTransactionalEvent',
@@ -447,7 +447,7 @@ test('getWorkflow', async () => {
 
   const sdkArgs = [workflowId]
   const apiParameters = { WORKFLOW_ID: workflowId }
-  const apiOptions = createSwaggerOptions()
+  const apiOptions = createSwaggerOptions({ body: null })
 
   return expect(() => standardTest({
     fullyQualifiedApiName: 'workflow.getWorkflow',
@@ -559,7 +559,7 @@ test('controlWorkflow - invalid resource', async () => {
 test('getAllOrgUnits', async () => {
   const sdkArgs = []
   const apiParameters = { EXT: '', FILTERS: [], freeForm: {} } // equiv to default
-  const apiOptions = createSwaggerOptions()
+  const apiOptions = createSwaggerOptions({ body: null })
 
   return expect(() => standardTest({
     fullyQualifiedApiName: 'organization.getAllOrgUnits',
@@ -575,7 +575,7 @@ test('getProfileWithOrgUnit', async () => {
 
   const sdkArgs = [pkey]
   const apiParameters = { PROFILE_PKEY: pkey }
-  const apiOptions = createSwaggerOptions()
+  const apiOptions = createSwaggerOptions({ body: null })
 
   return expect(() => standardTest({
     fullyQualifiedApiName: 'organization.getProfileWithOrgUnit',
@@ -634,7 +634,7 @@ test('getDataFromRelativeUrl', async () => {
 
   const sdkArgs = [relativeUrl]
   const apiParameters = { RELATIVE_URL: relativeUrl }
-  const apiOptions = createSwaggerOptions()
+  const apiOptions = createSwaggerOptions({ body: null })
 
   return expect(() => standardTest({
     fullyQualifiedApiName: 'util.getDataFromRelativeUrl',
@@ -650,7 +650,7 @@ test('getAllCustomResources', async () => {
 
   const sdkArgs = [customResource]
   const apiParameters = { CUSTOMRESOURCE: customResource, EXT: '', FILTERS: [], freeForm: {} } // equiv to default
-  const apiOptions = createSwaggerOptions()
+  const apiOptions = createSwaggerOptions({ body: null })
 
   return expect(() => standardTest({
     fullyQualifiedApiName: 'customresource.getAllCustomResources',
@@ -667,7 +667,7 @@ test('getAllProfileAndServicesExt', async () => {
   const sdkArgs = [customResource]
   const apiParameters = { CUSTOMRESOURCE: customResource, EXT: '', FILTERS: [], freeForm: {} } // equiv to default
   const sdkFunctionName = 'getAllProfileAndServicesExt'
-  const apiOptions = createSwaggerOptions()
+  const apiOptions = createSwaggerOptions({ body: null })
   return expect(() => standardTest({
     fullyQualifiedApiName: 'customresource.getAllCustomResources',
     apiParameters,
@@ -683,7 +683,7 @@ test('getAllBasicCustomResources', async () => {
 
   const sdkArgs = [customResource]
   const apiParameters = { RESOURCE: customResource }
-  const apiOptions = createSwaggerOptions()
+  const apiOptions = createSwaggerOptions({ body: null })
 
   return expect(() => standardTest({
     fullyQualifiedApiName: 'basiccustomresource.getAllBasicCustomResources',
@@ -699,7 +699,7 @@ test('getMetadataForResourceExt', async () => {
 
   const sdkArgs = [resource]
   const apiParameters = { RESOURCE: resource }
-  const apiOptions = createSwaggerOptions()
+  const apiOptions = createSwaggerOptions({ body: null })
 
   return expect(() => standardTest({
     fullyQualifiedApiName: 'metadataExt.getMetadataForResourceExt',


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->
#82 
GET calls fail with swagger client 3.10.2 or higher because of empty body in get calls.
Fixed this.

## Description

<!--- Describe your changes in detail -->

## Related Issue

<!--- This project only accepts pull requests related to open issues -->
<!--- If suggesting a new feature or change, please discuss it in an issue first -->
<!--- If fixing a bug, there should be an issue describing it with steps to reproduce -->
<!--- Please link to the issue here: -->

## Motivation and Context

<!--- Why is this change required? What problem does it solve? -->

## How Has This Been Tested?

e2e tests, unit tests

## Screenshots (if appropriate):

## Types of changes

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [x] I have signed the [Adobe Open Source CLA](http://opensource.adobe.com/cla.html).
- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [x] I have read the **CONTRIBUTING** document.
- [x] I have added tests to cover my changes.
- [x] All new and existing tests passed.
